### PR TITLE
Added several options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ PrintCode converts the code being edited into an HTML file, displays it by brows
 
 ## Configuration Options
 
-Key              | Default | Description
------------------|--------:|-------------
-tabSize          |       2 | The number of spaces a tab is equal to
-fontSize         |      12 | Controls the font size in pixels
-browserPath      |    none | Open with your non-default browser
-webServerPort    |    3000 | Port number for local WebServer.
-disableTelemetry |   false | Dont't include Google Analytics code on page
+Key              | Default  | Description
+-----------------|---------:|-------------
+tabSize          |        2 | The number of spaces a tab is equal to
+fontSize         |       12 | Controls the font size in pixels
+printFilePath    | filename | Amount of file's path info in document title
+browserPath      |     none | Open with your non-default browser
+webServerPort    |     3000 | Port number for local WebServer.
+disableTelemetry |    false | Dont't include Google Analytics code on page
 
 ## Release Notes
 
 See [Changelog](https://github.com/nobuhito/vscode.printcode/blob/master/CHANGELOG.md).
-

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ Key              | Default  | Description
 -----------------|---------:|-------------
 tabSize          |        2 | The number of spaces a tab is equal to
 fontSize         |       12 | Controls the font size in pixels
+paperSize        |       a4 | Paper size and orientation
+lineNumbers      |       on | Print line numbers
 printFilePath    | filename | Amount of file's path info in document title
 browserPath      |     none | Open with your non-default browser
 webServerPort    |     3000 | Port number for local WebServer.
 disableTelemetry |    false | Dont't include Google Analytics code on page
+autoPrint        |     true | Pop up print dialog automatically
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can print the code from VSCode!
 
 [Product page](https://printcode.launchaco.com/)
 
-[README for Japnese](https://github.com/nobuhito/vscode.printcode/blob/master/README.ja.md)
+[README for Japanese](https://github.com/nobuhito/vscode.printcode/blob/master/README.ja.md)
 
 [Blog for Japanese](https://about.gitlab.com/2017/12/04/illustrations-and-icons-on-gitlab-com/)
 
@@ -28,19 +28,21 @@ PrintCode converts the code being edited into an HTML file, displays it by brows
 ## Usage
 
 1. Press the `F1` key
-2. Select or Type `PrintCode`
+2. Select or type `PrintCode`
 3. The browser launches and displays the code
 4. A print dialog opens and you can print!!
 
 ## Configuration Options
 
-Key           | Default | Description
---------------|--------:|-------------
-tabSize       |       2 | The number of spaces a tab is equal to
-fontSize      |      12 | Controls the font size in pixels
-browserPath   |    none | Open with your non-default browser
-webServerPort |    3000 | Port number for local WebServer.
+Key              | Default | Description
+-----------------|--------:|-------------
+tabSize          |       2 | The number of spaces a tab is equal to
+fontSize         |      12 | Controls the font size in pixels
+browserPath      |    none | Open with your non-default browser
+webServerPort    |    3000 | Port number for local WebServer.
+disableTelemetry |   false | Dont't include Google Analytics code on page
 
 ## Release Notes
 
 See [Changelog](https://github.com/nobuhito/vscode.printcode/blob/master/CHANGELOG.md).
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "printcode",
     "displayName": "PrintCode",
     "description": "Added printing function to VS Code!!",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "author": {
         "name": "Nobuhito SATO",
         "email": "nobuhito.sato@gmail.com",
@@ -39,6 +39,18 @@
                         "description": "Controls the font size in pixels.",
                         "default": 12
                     },
+                    "printcode.paperSize": {
+                        "type": "string",
+                        "description": "Paper size and orientation.",
+                        "enum": [ "a4", "a4Land", "letter", "letterLand" ],
+                        "default": "a4"
+                    },
+                    "printcode.lineNumbers": {
+                        "type": "string",
+                        "description": "Print line numbers.",
+                        "enum": [ "on", "off", "editor" ],
+                        "default": "on"
+                    },
                     "printcode.printFilePath": {
                         "type": "string",
                         "description": "Amount of file's path info in document title.",
@@ -58,6 +70,11 @@
                         "type": "boolean",
                         "description": "Dont't include Google Analytics code on page.",
                         "default": false
+                    },
+                    "printcode.autoPrint": {
+                        "type": "boolean",
+                        "description": "Pop up print dialog automatically.",
+                        "default": true
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "printcode",
     "displayName": "PrintCode",
     "description": "Added printing function to VS Code!!",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "author": {
         "name": "Nobuhito SATO",
         "email": "nobuhito.sato@gmail.com",
@@ -47,6 +47,11 @@
                         "type": "integer",
                         "description": "Port number for local WebServer.",
                         "default": 3000
+                    },
+                    "printcode.disableTelemetry": {
+                        "type": "boolean",
+                        "description": "Dont't include Google Analytics code on page.",
+                        "default": false
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "printcode",
     "displayName": "PrintCode",
     "description": "Added printing function to VS Code!!",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "author": {
         "name": "Nobuhito SATO",
         "email": "nobuhito.sato@gmail.com",
@@ -38,6 +38,12 @@
                         "type": "integer",
                         "description": "Controls the font size in pixels.",
                         "default": 12
+                    },
+                    "printcode.printFilePath": {
+                        "type": "string",
+                        "description": "Amount of file's path info in document title.",
+                        "default": "filename",
+                        "enum": ["none", "full", "relative", "filename"]
                     },
                     "printcode.browserPath": {
                         "type": "string",

--- a/src/extension.js
+++ b/src/extension.js
@@ -100,6 +100,19 @@ function buildHtml(text, language) {
     let tabSize = myConfig.get("tabSize");
     let fontSize = myConfig.get("fontSize");
     let fontFamily = vscode.workspace.getConfiguration("editor", null).get("fontFamily");
+    let disableTelemetry = myConfig.get("disableTelemetry");
+
+    let googleAnalyticsSnipplet = disableTelemetry ? '' : `
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112594767-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-112594767-1');
+    </script>
+    `;
 
     let html = `
 <!doctype html>
@@ -135,16 +148,7 @@ function buildHtml(text, language) {
             }
         }
     </style>
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112594767-1"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'UA-112594767-1');
-    </script>
+    ${googleAnalyticsSnipplet}
 </head>
 <body>
 


### PR DESCRIPTION
Added multiple config options to manage how extension behaves and how printout will look like. With defaults values (shown with asterisk*) the extension works as previously except filename is included in document's `<title></title>`. New options are:

* `disableTelemetry`: `true`, `false`*
* `printFilePath`: `none`, `filename`*, `relative`, `full`
* `paperSize`: `a4`*, `a4Land`, `letter`, `letterLand`
* `lineNumbers`: `on`*, `off`, `editor`
* `autoPrint`: `true`*, `false`

