### PR TITLE
Some fixes (but not: webServerPort not available, blank browser tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 2.1.0
 
-* Added several options #6 (Thank you @jailahti)
-  * PaperSize, LineNumbers, PrintFilePath, DisableTelemetry, AutoPrint
+* Added several options #6 (Thank you @janilahti)
+  * paperSize, lineNumbers, printFilePath, disableTelemetry, autoPrint
 * Changed default port for web server to 4649
 * Updated Codemirror to v5.35
 * Fixed minor bugs and documents.

--- a/package.json
+++ b/package.json
@@ -43,10 +43,16 @@
                         "type": "string",
                         "description": "Paper size and orientation.",
                         "enum": [
+                            "a3",
+                            "a3Land",
                             "a4",
                             "a4Land",
+                            "a5",
+                            "a5Land",
                             "letter",
-                            "letterLand"
+                            "letterLand",
+                            "legal",
+                            "legalLand"
                         ],
                         "default": "a4"
                     },

--- a/src/extension.js
+++ b/src/extension.js
@@ -155,6 +155,9 @@ function buildHtml(text, language) {
   let multiplex = "/_node_modules/codemirror/addon/mode/multiplex.js";
   let htmlmixed = "/_node_modules/codemirror/mode/htmlmixed/htmlmixed.js";
 
+  // for php
+  let clike = "/_node_modules/codemirror/mode/clike/clike.js";
+
   let myConfig = vscode.workspace.getConfiguration("printcode", null);
   let tabSize = myConfig.get("tabSize");
   let fontSize = myConfig.get("fontSize");
@@ -276,23 +279,26 @@ function buildHtml(text, language) {
 
     <script>
         var head = document.getElementsByTagName("head")[0];
+        var addScripts = [];
 
         if (["htmlembedded", "htmlmixed"].indexOf("${mode}") > -1) {
-            var addScripts = ["${xml}", "${javascript}", "${stylesheet}"];
-            for (var script of addScripts) {
-                var source = document.createElement("script");
-                source.setAttribute("src", script);
-                head.appendChild(source);
-            }
+          addScripts.push("${xml}", "${javascript}", "${stylesheet}");
         }
 
         if ("${mode}" == "htmlembedded") {
-            var addScripts = ["${multiplex}", "${htmlmixed}"];
-            for (var script of addScripts) {
-                var source = document.createElement("script");
-                source.setAttribute("src", script);
-                head.appendChild(source);
-            }
+          addScripts.push("${multiplex}", "${htmlmixed}");
+        }
+
+        if ("${mode}" == "php") {
+          addScripts.push("${xml}", "${javascript}", "${stylesheet}", "${htmlmixed}", "${clike}");
+        }
+
+        if (addScripts.length > 0) {
+          for (var script of addScripts) {
+            var source = document.createElement("script");
+            source.setAttribute("src", script);
+            head.appendChild(source);
+          }
         }
 
         window.addEventListener("load", function(event) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -128,6 +128,14 @@ function buildHtml(text, language) {
 
   // these could be moved to package.json as configuration objects
   let paperSpecs = {
+    a3: {
+      name: "A3",
+      width: "297mm"
+    },
+    a3Land: {
+      name: "A3 landscape",
+      width: "420mm"
+    },
     a4: {
       name: "A4",
       width: "210mm"
@@ -136,13 +144,29 @@ function buildHtml(text, language) {
       name: "A4 landscape",
       width: "297mm"
     },
+    a5: {
+      name: "A5",
+      width: "148mm"
+    },
+    a5Land: {
+      name: "A5 landscape",
+      width: "210mm"
+    },
     letter: {
       name: "letter",
       width: "216mm"
     },
     letterLand: {
       name: "letter landscape",
-      width: "279mm"
+      width: "280mm"
+    },
+    legal: {
+      name: "legal",
+      width: "216mm"
+    },
+    legalLand: {
+      name: "legal landscape",
+      width: "357mm"
     }
   };
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,7 +7,6 @@ const codemirror = require("codemirror/addon/runmode/runmode.node.js");
 require("codemirror/mode/meta.js");
 
 let server = null;
-let portNumberInUse = null;
 
 function activate(context) {
   let disposable = vscode.commands.registerCommand(
@@ -17,63 +16,37 @@ function activate(context) {
         .getConfiguration("printcode")
         .get("webServerPort");
 
-      if (server !== null && port !== portNumberInUse) {
-        server.close(function () { });
-        server = null;
-      }
-
       if (server == null) {
         server = http.createServer(requestHandler);
-        server.on('error', function (err) {
-            vscode.window.showInformationMessage(
-                `Unable to print: Port ${port} is in use. \
-                Please set different port number in User Settings: printcode.webServerPort \
-                or stop the active server which has reserved the port.`
-            );
-            server.close();
-            server = null;
-            return console.log(err);
-        });
-        server.on('request', (request, response) => {
-            response.on('finish', () => {
-                request.socket.destroy();
-            });
-        });
         server.listen(port, err => {
           if (err) {
             return console.log(err);
           }
-          portNumberInUse = port;
-          printIt();
         });
-      } else {
-        printIt();
       }
 
-      function printIt() {
-        let editor = vscode.window.activeTextEditor;
-        let language = editor.document.languageId;
-        var mode = resolveAliases(language);
-        let url = "http://localhost:" + port + "/?mode=" + mode;
+      let editor = vscode.window.activeTextEditor;
+      let language = editor.document.languageId;
+      var mode = resolveAliases(language);
+      let url = "http://localhost:" + port + "/?mode=" + mode;
 
-        let browserPath = vscode.workspace
-          .getConfiguration("printcode")
-          .get("browserPath");
-        if (browserPath != "") {
-          child_process.exec('"' + browserPath + '" ' + url);
-        } else {
-          let platform = process.platform;
-          switch (platform) {
-            case "darwin":
-              child_process.exec("open " + url);
-              break;
-            case "linux":
-              child_process.exec("xdg-open " + url);
-              break;
-            case "win32":
-              child_process.exec("start " + url);
-              break;
-          }
+      let browserPath = vscode.workspace
+        .getConfiguration("printcode")
+        .get("browserPath");
+      if (browserPath != "") {
+        child_process.exec('"' + browserPath + '" ' + url);
+      } else {
+        let platform = process.platform;
+        switch (platform) {
+          case "darwin":
+            child_process.exec("open " + url);
+            break;
+          case "linux":
+            child_process.exec("xdg-open " + url);
+            break;
+          case "win32":
+            child_process.exec("start " + url);
+            break;
         }
       }
     }


### PR DESCRIPTION
This PR addresses following issues:
* ~~#4 Show information message and don't launch browser if `webServerPort` is not available (reserved by another process).~~ Removed from this PR to be added later with enchancement.
* #8 Print PHP files correctly.
* #9 Add more paper sizes (a3, a5, legal).