### PR TITLE
Added possibility to print only a part of document

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ PrintCode converts the code being edited into an HTML file, displays it by brows
 | fontSize         |       12 | Controls the font size in pixels             |
 | paperSize        |       a4 | Paper size and orientation                   |
 | lineNumbers      |       on | Print line numbers                           |
+| useTrueLineNumbers |   true | When printing a region, don't start from 1   |
+| skipBeforeTag    | PRINTCODE_SKIPBEFORE | Don't print anything before this string |
+| skipAfterTag     | PRINTCODE_SKIPAFTER  | Don't print anything after this string  |
 | printFilePath    | filename | Amount of file's path info in document title |
 | browserPath      |     none | Open with your non-default browser           |
 | webServerPort    |     4649 | Port number for local WebServer.             |

--- a/package.json
+++ b/package.json
@@ -66,6 +66,21 @@
             ],
             "default": "on"
           },
+					"printcode.useTrueLineNumbers": {
+						"type": "boolean",
+						"description": "If printing partial file, don't start count from 1.",
+						"default": true
+					},
+					"printcode.skipBeforeTag": {
+						"type": "string",
+						"description": "Tag to separate non-printing part -- skip lines before this.",
+						"default": "PRINTCODE_SKIPBEFORE"
+					},
+					"printcode.skipAfterTag": {
+						"type": "string",
+						"description": "Tag to separate non-printing part -- skip lines after this.",
+						"default": "PRINTCODE_SKIPAFTER"
+					},
           "printcode.printFilePath": {
             "type": "string",
             "description": "Amount of file's path info in document title.",


### PR DESCRIPTION
New feature allows defining a region to be printed instead of a whole document. If tags are added in document (for example inside a comment) those tags mark region boundaries for printing.

- Using _skip-before tag_ the code lines after the tag string will be printed.
- Using _skip-after tag_ the start of the code will be printed up to but not including the tag string.
- Using _both_ tags it's possible to print a specified region.

The tags can, but are not forced to, be inside a code comment. Currently following characters preceding the tags are understood as being part of the comment syntax: `/*#'%!-`.

New settings:
- `useTrueLineNumbers`: When printing a region, don't start numbering from 1, instead show original line numbers (default: `true`)
- `skipBeforeTag`: Don't print anything before this string (default: `PRINTCODE_SKIPBEFORE`)
- `skipAfterTag`: Don't print anything after this string (default: `PRINTCODE_SKIPAFTER`)
